### PR TITLE
[Feature] Remove Stopword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 
 ## Jupyter notebook ##
 .ipynb_checkpoints
+*.ipynb
 
 ## etc
 assets
@@ -15,3 +16,7 @@ runs/
 
 ## wandb
 wandb/
+
+## dataset
+new_dataset/
+concat_dataset/

--- a/delete_stopword.py
+++ b/delete_stopword.py
@@ -5,19 +5,25 @@
         output: stopword가 제거된 passage 반환
 
 """
-from konlpy.tag import Okt # pip install tweepy==3.10.0 호환성 문제 있음 apt install default-jdk
+from konlpy.tag import Okt # pip install tweepy==3.10.0 호환성 문제 있다면 --> apt install default-jdk
 from transformers import AutoTokenizer
+from datasets import (
+    Dataset,
+    DatasetDict,
+    load_from_disk
+)
+from tqdm import tqdm
 
 class DeleteStopword:
     def __init__(self, tokenizer, stopwords_path:str = './stopwords.txt') -> None:
-        self.stopwords = []
-        self.ad_stopwords = []
+        self.stopwords = [] # text 파일 기반의 불용어 리스트입니다
+        self.ad_stopwords = [] # Okt 형태소 분석 기반의 불용어(형용사, 부사) 리스트입니다.
         self.okt = Okt()
         self.tokenizer = tokenizer
 
         print("[INIT] DeleteStopword...")
 
-        # stopword 리스트 파일을 참조하여 불용어 리스트를 만듭니다.
+        # stopword.txt 파일을 참조하여 불용어 리스트를 만듭니다.
         with open(stopwords_path, 'r', encoding='utf-8') as f:
             temps = f.readlines()
             for word in temps:
@@ -27,7 +33,7 @@ class DeleteStopword:
 
     def remove_stopwords(self, passage:str) -> str:
         """
-            입력으로 들어온 스트링에서 불용어 리스트(self.stopwords)에 해당하는 토큰을 제거한 후 반환합니다.
+            입력으로 들어온 스트링에서 txt파일 기반 불용어 리스트(self.stopwords)에 해당하는 토큰을 제거한 후 반환합니다.
             input: str
             output: str - 불용어가 제거된 스트링
         """
@@ -62,13 +68,29 @@ class DeleteStopword:
 
     def find_answer_index(self, passage:str, answer:str) -> int:
         """
-            passage에서 answer word의 시작 인덱스를 찾아 반환합니다. 이를 통해 새로운 데이터셋을 구축할 수 있습니다.
+            passage에서 answer word의 시작 인덱스를 찾아 반환합니다. 불용어 제거로 인해 answer text의 위치를 정정하는 작업입니다.
+            이를 통해 새로운 데이터셋을 구축할 수 있습니다.
             return
                 'answer_start' : passage에서 answer word가 시작되는 index입니다.
         """
         answer_start = passage.find(answer)
+        if answer_start == -1:
+            # answer를 못 찾는 경우가 있음 -> 불용어로 판단되서 제거되었기 때문(?) 혹은 answer가 너무 길어서...
+            # 그냥 무시하기 or answer는 고정시키고 그 외의 불용어 제거하기
+            pass
 
         return answer_start
+
+    def refactt(self, example:Dataset)-> Dataset:
+        """
+            Dataset 클래스를 입력으로 받아 context의 불용어를 제거하고 asnwer_start를 조정하여 새로운 Dataset으로 반환합니다. 
+            그 외의 항목들은 그대로 사용합니다.
+        """
+        example['context'] = self.konlpy_okt(example['context'])
+        example['answers']['answer_start'][0] = self.find_answer_index(example['context'], example['answers']['text'][0])
+        example['id'] = example['id'] + "-aug"
+
+        return example
         
 
             
@@ -77,40 +99,97 @@ class DeleteStopword:
 ############
 ### DEMO ###
 ############
+"""
+    `python delete_stopword.py`로 실행하면 ./concat_datset 디렉토리에 [기존 데이터셋 + 불용어 제거된 데이터셋]이 등장합니다.
+    ./new_dataset 디렉토리에는 [불용어 제거된 데이터셋] 만 저장됩니다.
+"""
 
+
+# 토크나이저 및 DeleteStopword class 호출
 tokenizer = AutoTokenizer.from_pretrained(
     "klue/roberta-large",
     use_fast=True,
     )
-
 ds = DeleteStopword(tokenizer=tokenizer)
+dataset = load_from_disk("../data/train_dataset/") # 기존 데이터셋
+
+
+if load_from_disk('./new_dataset') is None:
+    new_dataset = dataset.map(ds.refactt) # 불용어 제거 시작
+    new_dataset.save_to_disk('./new_dataset') # 불용어가 제거된 데이터셋을 디렉토리에 저장합니다.
+else:
+    new_dataset = load_from_disk('./new_dataset') # 불용어가 제거된 데이터셋이 이미 있다면 불러옵니다
+
+print(dataset)
+print(new_dataset)
+
+err_count = 0
+
+print('Working for Train set')
+for new_data in tqdm(new_dataset['train']):
+    # answer_start != -1 인 경우만 add item하기
+    if new_data['answers']['answer_start'][0] != -1:
+        dataset['train'] = dataset['train'].add_item(new_data) # datasets==1.7.v 부터 사용 가능합니다
+    else:
+        #print(f"{new_data['id']}는 답이 context에 존재하지 않음!")
+        err_count += 1
+
+print(f'[no-answer]: {err_count} 건에 대해서는 answer가 제거되어 적용하지 않았습니다.')
+err_count = 0
+
+print('Working for Validation set')
+for new_data in tqdm(new_dataset['validation']):
+    # answer_start != -1 인 경우만 add item하기
+    if new_data['answers']['answer_start'][0] != -1:
+        dataset['validation'] = dataset['validation'].add_item(new_data)
+    else:
+        #print(f"{new_data['id']}는 답이 context에 존재하지 않음!")
+        err_count += 1
+print(f'[no-answer]: {err_count} 건에 대해서는 answer가 제거되어 적용하지 않았습니다.')
+
+#new_item = new_dataset['train'][0]
+#dataset['train'] = dataset['train'].add_item(new_item) # datasets==1.7.부터 사용 가능
+print('==========RESULT==============')
+print(dataset)
+
+dataset.save_to_disk('./concat_dataset')
+print('save done...')
 
 
 
-from datasets import load_from_disk
-dataset = load_from_disk("../data/train_dataset/")
 
-#context = dataset['train'][0]['context']
-#answer = dataset['train'][0]['answers']['text'][0] # answer가 2개 이상인 경우는 없는듯
 
-#ds.remove_stopwords(context)
+#print('================================================================')
+#print(dataset['validation'][1])
+#print('================================================================')
+#print(new_dataset['validation'][1])
+#print('================================================================')
 
-#r = ds.konlpy_okt(context)
-#print(r)
-#ds.find_answer_index(context, answer)
+#print(dataset['train'].keys())
+#print(dataset['validation'].keys())
+#print(new_dataset.keys())
 
-for data in dataset['train']:
-    #print(type(data)) 'dict'
-    context = data['context']
-    answer = data['answers']['text'][0]
-    
-    new_document_id = data['document_id'] + 1 # 어떤 수를 더해야 중복되지 않을까?
-    new_id = data['id'] + "-aug"
 
-    new_context = ds.konlpy_okt(context)
-    new_answer_start = ds.find_answer_index(new_context, answer)
 
-    print(new_context)
-    print(new_answer_start)
+#dataset.update(new_dataset)
 
-    break
+
+
+#print(dataset['validation'][1])
+
+
+
+
+
+
+"""
+def add_prefix(example):
+    example["text"] = "Review: " + example["text"]
+    return example
+
+dataset = dataset.map(add_prefix)
+dataset["train"][0:3]["text"]
+
+dataset = dataset.map(lambda example: tokenizer(example["text"]), batched=True)
+dataset = dataset.map(add_prefix, num_proc=4)
+"""


### PR DESCRIPTION
데이터셋에서 불용어를 제거하여 새로운 데이터셋을 만드는 기능을 합니다.

1. 기존 데이터셋을 불러옵니다
2. 형태소 분석기를  이용, context에서 형용사와 부사를 제거합니다
3. context의 수정에 따른 answer_start를 다시 조정합니다
4. 이상의 내용을 적용한 새로운 데이터셋을 ./new_dataset 디렉토리에 저장합니다
5. 이후 `기존 데이터셋` + `불용어 제거된 데이터셋` 을 ./concat_dataset 디렉토리에 저장합니다.

현재 새로운 데이터셋으로 학습을 진행 시 train.py --do_eval 태그를 넣으면 `ValueError: Predictions and/or references don't match the expected format.` 에러가 발생하는데, 학습 자체는 잘 이루어져서 모델 저장까지는 되는 것 같습니다. 이후 해당 모델로 inference 수행 후 결과물에는 이상이 없는 것으로 확인했습니다. 해당 버그는 추후 수정하는대로 업데이트 하겠습니다.